### PR TITLE
Add pytest-cov for coverage test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@
 *.swp
 *~
 .DS_Store
+/.coverage
 /build
 /dist
+/htmlcov
 /installed_files.txt
 /tmp
 /vendor

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,5 +7,7 @@ flake8-colors
 # flake8-pep257
 # Code Formatter
 pyformat
+# Coverage
+pytest-cov
 # Documentation
 # Sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     -rrequirements.txt
     -rtest-requirements.txt
 commands =
-    pytest -s -v {posargs} tests
+    pytest -s -v --cov=rpmlb --cov-report term --cov-report html {posargs} tests
 
 [testenv:integration]
 basepython = /usr/local/python-3.6.1/bin/python3


### PR DESCRIPTION
I added `pytest-cov` [1][2] for coverage test.
Right now the report format is HTML.

Use case is for example

```
$ tox -e py36
```

Then
See `htmlcov/index.html`

I thought `--cov-report html` option was better than `--cov-report term` option.
Though we can not see the report from Travis test, we can see a good looking HTML report from local.



* [1] https://pypi.python.org/pypi/pytest-cov
* [2] https://github.com/pytest-dev/pytest-cov