### PR TITLE
Custom file hacks necessary for rh-ror50

### DIFF
--- a/tests/fixtures/custom/rhpkg_internal_copr.yml
+++ b/tests/fixtures/custom/rhpkg_internal_copr.yml
@@ -18,6 +18,15 @@ build:
         sed -i 's/rh-nodejs6/rh-nodejs4/g' rh-ror50.spec
         sed -i 's/rh-mongodb32/rh-mongodb26/g' rh-ror50.spec
     fi
+  - | # Hack around flexmock bootstrap
+    if [ "$(basename $(realpath ..))" = "009" ]; then
+        sed -i '/^BuildRequires.*rubygem(rspec)$/ s/^/#/' rubygem-flexmock.spec
+        sed -i '/^%check$/,/^popd$/ s/^/#/' rubygem-flexmock.spec
+    fi
+  - | # Hack around railties dependency
+    if [ "${PKG}" = "rubygem-railties" ]; then
+        sed -i '/^patch -p2 < %{PATCH2}$/ s/^/#/' rubygem-railties.spec
+    fi
   - "rm -v *.rpm || true"
   - rhpkg --dist rhscl-2.4-rh-ror50-rhel-7 srpm
   - |


### PR DESCRIPTION
As said in title, this PR contains the shell hacks necessary for successful rebuilding of the `rh-ror50` SCL.
After the [recipe fixes](https://github.com/sclorg/rhscl-rebuild-recipes/pull/18) merge, it should be possible to rebuild the collection from scratch.

Of course, these hacks should be removed after they will be included in respective spec files.

**Note**: I'm not sure about the location and name of the file (`tests/fixtures/custom/rhpkg_internal_copr.yml`) – right now it feels as this file is part of the automated tests. Is that intentional, or should we rename/move the file to more appropriate location?