### PR TITLE
Change "properties without logic" to "instance variables".

### DIFF
--- a/rpmlb/app.py
+++ b/rpmlb/app.py
@@ -43,6 +43,8 @@ class Application:
 
             # Load recipe
             recipe = Recipe(args_dict['recipe_file'], args_dict['recipe_id'])
+            # Verify recipe data
+            recipe.verify()
 
             work = Work(recipe, **args_dict)
             # Load downloader

--- a/rpmlb/recipe.py
+++ b/rpmlb/recipe.py
@@ -15,24 +15,15 @@ class Recipe:
             raise ValueError('recipe_id is required.')
 
         self._recipe_id = recipe_id
-        self._recipe = None
 
         yaml = Yaml(file_path)
         LOG.debug('Loaded recipe: %s', file_path)
         recipe_dict = yaml.content
-        self._recipe = recipe_dict[recipe_id]
-        self._num_of_package = len(self._recipe['packages'])
-
-    @property
-    def recipe(self):
-        return self._recipe
-
-    @property
-    def num_of_package(self):
-        return self._num_of_package
+        self.recipe = recipe_dict[recipe_id]
+        self.num_of_package = len(self.recipe['packages'])
 
     def each_normalized_package(self):
-        packages = self._recipe['packages']
+        packages = self.recipe['packages']
         for package in packages:
             package_dict = {}
             # String or hash
@@ -52,7 +43,7 @@ class Recipe:
             yield package_dict
 
     def verify(self):
-        recipe = self._recipe
+        recipe = self.recipe
 
         if 'name' not in recipe:
             raise ValueError('name is required in the recipe.')
@@ -69,8 +60,6 @@ class Recipe:
             raise ValueError('packages is invalid in the recipe.')
         if not isinstance(recipe['packages'], list):
             raise ValueError('packages should be a list.')
-        if len(recipe['packages']) <= 0:
-            raise ValueError('packages should have a element > 0')
         for package_dict in self.each_normalized_package():
             assert(package_dict['name'])
 

--- a/rpmlb/work.py
+++ b/rpmlb/work.py
@@ -27,28 +27,24 @@ class Work:
         else:
             working_dir = tempfile.mkdtemp(prefix='rpmlb-')
         LOG.info('Working directory: %s', working_dir)
-        self._working_dir = working_dir
-
-    @property
-    def working_dir(self):
-        return self._working_dir
+        self.working_dir = working_dir
 
     def close(self):
-        if os.path.isdir(self._working_dir):
-            shutil.rmtree(self._working_dir)
+        if os.path.isdir(self.working_dir):
+            shutil.rmtree(self.working_dir)
 
     def num_name_from_count(self, count):
         num_name = self._num_dir_format % count
         return num_name
 
     def each_num_dir(self):
-        if not os.path.isdir(self._working_dir):
+        if not os.path.isdir(self.working_dir):
             ValueError('working_dir does not exist.')
 
         count = 1
         for package_dict in self._recipe.each_normalized_package():
             num_name = self.num_name_from_count(count)
-            num_dir = os.path.join(self._working_dir, num_name)
+            num_dir = os.path.join(self.working_dir, num_name)
 
             if not os.path.isdir(num_dir):
                 os.makedirs(num_dir)

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -21,5 +21,46 @@ def test_recipe_not_found():
         Recipe('tests/fixtures/recipes/ror.yml', 'dummy')
 
 
-def test_verify(ok_recipe):
-    assert ok_recipe.verify
+def test_verify_returns_true_on_valid_recipe(ok_recipe):
+    assert ok_recipe.verify()
+
+
+def test_verify_raises_error_on_recipe_without_name(ok_recipe):
+    del ok_recipe.recipe['name']
+    with pytest.raises(ValueError):
+        ok_recipe.verify()
+
+
+def test_verify_raises_error_on_recipe_with_empty_name(ok_recipe):
+    ok_recipe.recipe['name'] = ''
+    with pytest.raises(ValueError):
+        ok_recipe.verify()
+
+
+def test_verify_returns_true_on_recipe_without_requires(ok_recipe):
+    del ok_recipe.recipe['requires']
+    assert ok_recipe.verify()
+
+
+def test_verify_raises_error_on_recipe_with_non_list_requires(ok_recipe):
+    ok_recipe.recipe['requires'] = 'abc'
+    with pytest.raises(ValueError):
+        ok_recipe.verify()
+
+
+def test_verify_raises_error_on_recipe_without_packages(ok_recipe):
+    del ok_recipe.recipe['packages']
+    with pytest.raises(ValueError):
+        ok_recipe.verify()
+
+
+def test_verify_raises_error_on_recipe_with_empty_packages(ok_recipe):
+    ok_recipe.recipe['packages'] = []
+    with pytest.raises(ValueError):
+        ok_recipe.verify()
+
+
+def test_verify_raises_error_on_recipe_with_non_list_packages(ok_recipe):
+    ok_recipe.recipe['packages'] = 'abc'
+    with pytest.raises(ValueError):
+        ok_recipe.verify()


### PR DESCRIPTION
This fixes #23 only below part.

>   properties without logic? (recipe, work)
>    trying to make it public read only? "consenting adults"

I found out that `verify` method was not called.
So, I added 1 line to call verify method at `app.py`.
Ideally I should add the unit test to `test_app.py` for that.
But I did not add unit test for that to `test_app.py` this tme.
Because it's to prevent conflict. PR #21 is updating the file. 

Instead of that, I checked that `$ make venv-integration-test` was passed.
