### PR TITLE
Fix double spec modification

### DIFF
--- a/rpmlb/builder/base.py
+++ b/rpmlb/builder/base.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import sys
+from contextlib import contextmanager
 
 import retrying
 
@@ -94,7 +95,9 @@ class BaseBuilder:
     def build(self, package_dict, **kwargs):
         raise NotImplementedError('Implement this method.')
 
-    def edit_spec_file(self, spec_file):
+    @staticmethod
+    @contextmanager
+    def edit_spec_file(spec_file):
         spec_file_origin = '{0}.orig'.format(spec_file)
         os.rename(spec_file, spec_file_origin)
         fh_r = None
@@ -114,7 +117,7 @@ class BaseBuilder:
         if not isinstance(macros_dict, dict):
             return ValueError('macros should be dict object.')
 
-        for fh_r, fh_w in self.edit_spec_file(spec_file):
+        with self.edit_spec_file(spec_file) as (fh_r, fh_w):
             for key in list(macros_dict.keys()):
                 value = macros_dict[key]
                 if value is None or str(value) == '':
@@ -128,7 +131,7 @@ class BaseBuilder:
         if not isinstance(macros_dict, dict):
             return ValueError('macros should be dict object.')
 
-        for fh_r, fh_w in self.edit_spec_file(spec_file):
+        with self.edit_spec_file(spec_file) as (fh_r, fh_w):
             for line in fh_r:
                 line = line.rstrip()
                 for key in list(macros_dict.keys()):

--- a/rpmlb/builder/base.py
+++ b/rpmlb/builder/base.py
@@ -111,7 +111,8 @@ class BaseBuilder:
         """
 
         # Ensure path type
-        target_path = Path(target_path) if not isinstance(target_path, Path) else target_path
+        if not isinstance(target_path, Path):
+            target_path = Path(target_path)
 
         # Back up the original
         source_path = target_path.with_suffix('.spec.orig')

--- a/rpmlb/builder/base.py
+++ b/rpmlb/builder/base.py
@@ -97,13 +97,13 @@ class BaseBuilder:
 
     @staticmethod
     @contextmanager
-    def edit_spec_file(target: Path):
+    def edit_spec_file(target_path: Path):
         """Safely edit a SPEC file in-place.
 
         The target is backed up as '{target}.orig' if needed.
 
         Keyword arguments:
-            target: The modified SPEC file path.
+            target_path: The modified SPEC file path.
 
         Returns:
             Context manager providing open handles
@@ -111,18 +111,19 @@ class BaseBuilder:
         """
 
         # Ensure path type
-        target = Path(target) if not isinstance(target, Path) else target
+        target_path = Path(target_path) if not isinstance(target_path, Path) else target_path
 
         # Back up the original
-        source = target.with_suffix('.spec.orig')
-        if not source.exists():
-            target.rename(source)
+        source_path = target_path.with_suffix('.spec.orig')
+        if not source_path.exists():
+            target_path.rename(source_path)
 
         # Provide the handles
-        with source.open(mode='r') as src, target.open(mode='w') as tgt:
-            print('# Edited by rpmlb', file=tgt)
+        with source_path.open(mode='r') as source_file, \
+                target_path.open(mode='w') as target_file:
+            print('# Edited by rpmlb', file=target_file)
 
-            yield src, tgt
+            yield source_file, target_file
 
     def edit_spec_file_by_macros(self, spec_file, macros_dict):
         if not isinstance(macros_dict, dict):

--- a/tests/builder/test_base.py
+++ b/tests/builder/test_base.py
@@ -108,10 +108,10 @@ def get_mock_work():
 def test_double_edit(empty_spec_path):
     """Original spec file is not modified twice"""
 
-    def edit_file(builder, path, indicator='Test edit'):
+    def edit_file(path, indicator='Test edit'):
         """Single edit round"""
 
-        for (src, dst) in builder.edit_spec_file(str(path)):
+        with BaseBuilder.edit_spec_file(str(path)) as (src, dst):
             print(indicator, file=dst)
             dst.write(src.read())
 
@@ -121,9 +121,7 @@ def test_double_edit(empty_spec_path):
         with path.open() as handle:
             return sum(marker in line for line in handle)
 
-    builder = BaseBuilder()
-
     for indicator in ('First edit', 'Second edit'):
-        edit_file(builder, empty_spec_path, indicator)
+        edit_file(empty_spec_path, indicator)
         assert empty_spec_path.exists()
         assert count_markers(empty_spec_path) == 1


### PR DESCRIPTION
In preparation for implementation of #33, I rewrote the `BaseBuilder.edit_spec_file` function to a context manager. This change also adds a test for and fixes issue #18.