### PR TITLE
Set correct path for flake8.

### DIFF
--- a/rpmlb/cli.py
+++ b/rpmlb/cli.py
@@ -34,7 +34,8 @@ from .work import Work
 )
 @click.option(
     '--work-directory', '-w',
-    type=click.Path(exists=True, file_okay=False, writable=True, resolve_path=True),
+    type=click.Path(exists=True, file_okay=False, writable=True,
+                    resolve_path=True),
     default=None,
     help='Specify a working directory.',
 )
@@ -75,7 +76,9 @@ from .work import Work
 )
 @click.argument('recipe_name')
 def run(recipe_file, recipe_name, **option_dict):
-    """Download and build RPMs listed in RECIPE_FILE under RECIPE_NAME (such as 'python33')."""
+    """Download and build RPMs listed in RECIPE_FILE under RECIPE_NAME
+    (such as 'python33').
+    """
 
     # Load recipe and processing objects
     recipe = Recipe(recipe_file, recipe_name)

--- a/tox.ini
+++ b/tox.ini
@@ -30,5 +30,5 @@ deps =
 whitelist_externals =
     bash
 commands =
-    flake8 lib/rpmlb/ tests/ setup.py
+    flake8 --show-source --statistics rpmlb/ tests/ setup.py
     bash scripts/lint_bash.sh


### PR DESCRIPTION
@hroncok @khardix 

flake8 check did not work correctly for `rpmlb` directory.
flake8 did not complain for not existing directory `lib/rpmlb/`.

Actually current source has below result for flake8.

```
$ flake8 rpmlb/ tests/ setup.py
rpmlb/cli.py:37:80: E501 line too long (84 > 79 characters)
rpmlb/cli.py:78:80: E501 line too long (95 > 79 characters)
```

I added "--show-source --statistics" because those look more useful options.

```
$ flake8 --show-source --statistics rpmlb/ tests/ setup.py
rpmlb/cli.py:37:80: E501 line too long (84 > 79 characters)
    type=click.Path(exists=True, file_okay=False, writable=True, resolve_path=True),
                                                                               ^
rpmlb/cli.py:78:80: E501 line too long (95 > 79 characters)
    """Download and build RPMs listed in RECIPE_FILE under RECIPE_NAME (such as 'python33')."""
                                                                               ^
2     E501 line too long (84 > 79 characters)
```
