### PR TITLE
Remove assert method that is used in a file under rpmlb.

### DIFF
--- a/rpmlb/recipe.py
+++ b/rpmlb/recipe.py
@@ -61,6 +61,7 @@ class Recipe:
         if not isinstance(recipe['packages'], list):
             raise ValueError('packages should be a list.')
         for package_dict in self.each_normalized_package():
-            assert(package_dict['name'])
+            if not package_dict['name']:
+                raise ValueError('name is invalid in the package.')
 
         return True

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -64,3 +64,12 @@ def test_verify_raises_error_on_recipe_with_non_list_packages(ok_recipe):
     ok_recipe.recipe['packages'] = 'abc'
     with pytest.raises(ValueError):
         ok_recipe.verify()
+
+
+def test_verify_raises_error_on_recipe_with_empty_package_name(ok_recipe):
+    ok_recipe.recipe['packages'] = [
+        'foo',
+        ''
+    ]
+    with pytest.raises(ValueError):
+        ok_recipe.verify()


### PR DESCRIPTION
This PR is for https://github.com/sclorg/rpm-list-builder/issues/23

> recipe.py
>   verify is bad.
>     assserts for logic
>     create a verify_attribute function?

I could not understand this part. "create a verify_attribute function".
Could you explain about this?

Thanks.
