### PR TITLE
Allow type hinting in Python 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML
 retrying
 click
+typing


### PR DESCRIPTION
I would like to be able to specify type hints in function signatures. Unfortunately, the `typing` module, which is pretty much required for anything more complicated, is present in the standard library only from version 3.5.

I would like to add a `typing` dependency, so the type hinting could work even in the Python 3.4.