### PR TITLE
Replace Recipe ID to Collection ID.

### DIFF
--- a/docs/users_guide.md
+++ b/docs/users_guide.md
@@ -151,7 +151,7 @@ work_directory/
           --download DOWNLOAD_TYPE \
           --build BUILD_TYPE \
           RECIPE_FILE \
-          RECIPE_ID
+          COLLECTION_ID
 
 ### Select download type
 
@@ -164,7 +164,7 @@ work_directory/
           --source-directory SOURCE_DIRECTORY \
           ...
           RECIPE_FILE \
-          RECIPE_ID
+          COLLECTION_ID
 
 #### Rhpkg
 
@@ -175,7 +175,7 @@ work_directory/
           --branch BRANCH \
           ...
           RECIPE_FILE \
-          RECIPE_ID
+          COLLECTION_ID
 
 #### Custom download
 
@@ -187,7 +187,7 @@ work_directory/
           --custom-file CUSTOM_FILE \
           ...
           RECIPE_FILE \
-          RECIPE_ID
+          COLLECTION_ID
 
 2. What is the custom file? See [sample custom files](../tests/fixtures/custom). It is YAML file like `.travis.yml`. You can write shell script in the file.
 
@@ -205,7 +205,7 @@ work_directory/
           --work-directory WORK_DIRECTORY \
           ...
           RECIPE_FILE \
-          RECIPE_ID
+          COLLECTION_ID
 
 ### Select build type
 
@@ -219,7 +219,7 @@ work_directory/
           --mock-config MOCK_CONFIG \
           ...
           RECIPE_FILE \
-          RECIPE_ID
+          COLLECTION_ID
 
 #### Copr build
 
@@ -238,7 +238,7 @@ work_directory/
           --copr-repo COPR_REPO \
           ...
           RECIPE_FILE \
-          RECIPE_ID
+          COLLECTION_ID
 
 #### Custom build
 
@@ -250,7 +250,7 @@ work_directory/
           --custom-file CUSTOM_FILE \
           ...
           RECIPE_FILE \
-          RECIPE_ID
+          COLLECTION_ID
 
 2. What is the custom file? See [sample custom files](../tests/fixtures/custom). It is YAML file like `.travis.yml`. You can write shell script in the file.
 
@@ -266,7 +266,7 @@ work_directory/
           --build dummy \
           ...
           RECIPE_FILE \
-          RECIPE_ID
+          COLLECTION_ID
 
 
 ### Resume from any position of pacakges
@@ -280,4 +280,4 @@ work_directory/
           --resume 35 \
           ...
           RECIPE_FILE \
-          RECIPE_ID
+          COLLECTION_ID

--- a/rpmlb/recipe.py
+++ b/rpmlb/recipe.py
@@ -8,18 +8,18 @@ LOG = logging.getLogger(__name__)
 class Recipe:
     """A class to describe recipe data."""
 
-    def __init__(self, file_path, recipe_id):
+    def __init__(self, file_path, collection_id):
         if not file_path:
             raise ValueError('file_path is required.')
-        if not recipe_id:
-            raise ValueError('recipe_id is required.')
+        if not collection_id:
+            raise ValueError('collection_id is required.')
 
-        self._recipe_id = recipe_id
+        self._collection_id = collection_id
 
         yaml = Yaml(file_path)
         LOG.debug('Loaded recipe: %s', file_path)
         recipe_dict = yaml.content
-        self.recipe = recipe_dict[recipe_id]
+        self.recipe = recipe_dict[collection_id]
         self.num_of_package = len(self.recipe['packages'])
 
     def each_normalized_package(self):

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -12,7 +12,7 @@ WORK_DIR="${TMP_DIR}/work_directory"
 CUSTOM_DIR="${ROOT_DIR}/tests/fixtures/custom"
 CLI="rpmlb"
 RECIPE_ORG_FILE="${RECIPE_DIR}/ror.yml"
-RECIPE_ID="rh-ror50"
+COLLECTION_ID="rh-ror50"
 RECEIPE_TEST_MIN_FILE="${RECIPE_DIR}/ror_test_min.yml"
 RECEIPE_TEST_MACRO_FILE="${RECIPE_DIR}/ror_test_macro.yml"
 BRANCH="rhscl-2.4-rh-ror50-rhel-7"
@@ -76,7 +76,7 @@ prepare_work_dir() {
         --source-directory "${SOURCE_DIR}" \
         --work-directory "${WORK_DIR}" \
         "${RECEIPE_TEST_MACRO_FILE}" \
-        "${RECIPE_ID}"
+        "${COLLECTION_ID}"
     return "${?}"
 }
 
@@ -89,7 +89,7 @@ download_only_test() {
         --source-directory "${SOURCE_DIR}" \
         --work-directory "${test_work_dir}" \
         "${RECEIPE_TEST_MIN_FILE}" \
-        "${RECIPE_ID}"
+        "${COLLECTION_ID}"
     local status="${?}"
     rm -rf "${test_work_dir}"
     return "${status}"
@@ -105,7 +105,7 @@ download_from_local_and_build_with_dummy_test() {
         --source-directory "${SOURCE_DIR}" \
         --work-directory "${test_work_dir}" \
         "${RECEIPE_TEST_MIN_FILE}" \
-        "${RECIPE_ID}"
+        "${COLLECTION_ID}"
     local status="${?}"
     rm -rf "${test_work_dir}"
     return "${status}"
@@ -117,7 +117,7 @@ download_by_rhpkg_and_build_with_dummy_test() {
         --build dummy \
         --branch "${BRANCH}" \
         "${RECEIPE_TEST_MIN_FILE}" \
-        "${RECIPE_ID}"
+        "${COLLECTION_ID}"
     return "${?}"
 }
 
@@ -127,7 +127,7 @@ download_with_custom_and_build_with_dummy_test() {
         --build dummy \
         --custom-file "${CUSTOM_DIR}/echo.yml" \
         "${RECEIPE_TEST_MIN_FILE}" \
-        "${RECIPE_ID}"
+        "${COLLECTION_ID}"
     return "${?}"
 }
 
@@ -138,7 +138,7 @@ build_only_verbose_test() {
         --verbose \
         --work-directory "${WORK_DIR}" \
         "${RECEIPE_TEST_MIN_FILE}" \
-        "${RECIPE_ID}"
+        "${COLLECTION_ID}"
     return "${?}"
 }
 
@@ -155,7 +155,7 @@ build_only_with_mock_test() {
         --work-directory "${WORK_DIR}" \
         --mock-config "${MOCK_CONFIG}" \
         "${RECEIPE_TEST_MIN_FILE}" \
-        "${RECIPE_ID}"
+        "${COLLECTION_ID}"
     return "${?}"
 }
 
@@ -170,7 +170,7 @@ build_only_with_custom_echo_test() {
         --work-directory "${WORK_DIR}" \
         --custom-file "${CUSTOM_DIR}/echo.yml" \
         "${RECEIPE_TEST_MIN_FILE}" \
-        "${RECIPE_ID}"
+        "${COLLECTION_ID}"
     return "${?}"
 }
 
@@ -182,7 +182,7 @@ build_only_with_custom_mock_test() {
         --work-directory "${WORK_DIR}" \
         --custom-file "${CUSTOM_DIR}/rhpkg_mock.yml" \
         "${RECEIPE_TEST_MIN_FILE}" \
-        "${RECIPE_ID}"
+        "${COLLECTION_ID}"
     return "${?}"
 }
 
@@ -195,7 +195,7 @@ build_only_resume_test() {
         --resume 3 \
         --custom-file "${CUSTOM_DIR}/echo.yml" \
         "${RECEIPE_TEST_MACRO_FILE}" \
-        "${RECIPE_ID}"
+        "${COLLECTION_ID}"
     return "${?}"
 }
 
@@ -209,7 +209,7 @@ download_and_build_with_custom_echo_test() {
         --work-directory "${test_work_dir}" \
         --custom-file "${CUSTOM_DIR}/echo.yml" \
         "${RECEIPE_TEST_MACRO_FILE}" \
-        "${RECIPE_ID}"
+        "${COLLECTION_ID}"
     return "${?}"
 }
 
@@ -223,7 +223,7 @@ download_and_build_with_custom_mock_test() {
         --work-directory "${test_work_dir}" \
         --custom-file "${CUSTOM_DIR}/rhpkg_mock.yml" \
         "${RECEIPE_TEST_MIN_FILE}" \
-        "${RECIPE_ID}"
+        "${COLLECTION_ID}"
     return "${?}"
 }
 


### PR DESCRIPTION
Because the definition has explicitly been explained as Collection ID at below document.
https://github.com/sclorg/rhscl-rebuild-recipes/blob/master/README.md

Fixes https://github.com/sclorg/rpm-list-builder/issues/26

I did below operation, and ran `tests/integration/run.sh` just in case.

```
$ git clean -fdx 

$ grep -ri 'recipe[_ ]id' *

$ grep -rl RECIPE_ID | xargs sed -i 's/RECIPE_ID/COLLECTION_ID/g'

$ grep -rl recipe_id | xargs sed -i 's/recipe_id/collection_id/g'
```
