### PR TITLE
Add Travis Build Status Badge to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RPM List Builder
 
+[![Travis Build Status](https://travis-ci.org/sclorg/rpm-list-builder.svg?branch=master)](https://travis-ci.org/sclorg/rpm-list-builder)
+
 RPM List Builder (rpmlb) helps you to build a list of defined RPM packages including Red Hat Software Collection (SCL) continually from the [recipe file](https://github.com/sclorg/rhscl-rebuild-recipes).
 
 


### PR DESCRIPTION
This PR fixes https://github.com/sclorg/rpm-list-builder/issues/43

I added Travis Build Status Badge to README.
You can see the added badge image in below URL.
https://github.com/junaruga/rpm-list-builder/blob/feature/readme-add-travis-badge/README.md


I referred below sites too.
https://github.com/rails/rails/blob/master/README.md
https://github.com/rubygems/rubygems/blob/master/README.md

I used official Travis badge URL for that, because I have never seen the alias URL `https://img.shields.io/travis/USER/REPO/BRANCH.svg` in my past experience that I have seen the Travis badge image URLs in the README file in more than 50 packages.
