### PR TITLE
Implement cmd element in a recipe file

### DIFF
--- a/rpmlb/builder/base.py
+++ b/rpmlb/builder/base.py
@@ -8,6 +8,7 @@ from typing import Any, Iterator, Mapping, Match
 import retrying
 
 from .. import utils
+from ..yaml import Yaml
 
 LOG = logging.getLogger(__name__)
 
@@ -124,6 +125,9 @@ class BaseBuilder:
             )
 
             target_file.write(''.join(content_stream))  # End modifications
+
+        if 'cmd' in package_dict:
+            Yaml.run_cmd_element(package_dict['cmd'])
 
     @retrying.retry(stop_max_attempt_number=3)
     def build_with_retrying(self, package_dict, **kwargs):

--- a/rpmlb/custom.py
+++ b/rpmlb/custom.py
@@ -18,14 +18,15 @@ class Custom:
         if 'name' in kwargs:
             env['PKG'] = kwargs['name']
 
-        cmd_dict = self._get_yaml_content()
+        cmd_dict = self.yaml_content
         if key not in cmd_dict:
             return
         cmd_element = cmd_dict[key]
 
         Yaml.run_cmd_element(cmd_element, env=env)
 
-    def _get_yaml_content(self):
+    @property
+    def yaml_content(self):
         if self._yaml_content:
             return self._yaml_content
         yaml = Yaml(self._file_path)

--- a/rpmlb/custom.py
+++ b/rpmlb/custom.py
@@ -1,6 +1,5 @@
 import logging
 
-from rpmlb import utils
 from rpmlb.yaml import Yaml
 
 LOG = logging.getLogger(__name__)
@@ -19,20 +18,16 @@ class Custom:
         if 'name' in kwargs:
             env['PKG'] = kwargs['name']
 
-        for cmd in self.each_yaml_cmd(key):
-            utils.run_cmd(cmd, env=env)
-
-    def each_yaml_cmd(self, key):
-        cmd_dict = self._get_yaml_content(self._file_path)
+        cmd_dict = self._get_yaml_content()
         if key not in cmd_dict:
             return
-        cmds = cmd_dict[key]
-        for cmd in cmds:
-            yield cmd
+        cmd_element = cmd_dict[key]
 
-    def _get_yaml_content(self, file_path):
+        Yaml.run_cmd_element(cmd_element, env=env)
+
+    def _get_yaml_content(self):
         if self._yaml_content:
             return self._yaml_content
-        yaml = Yaml(file_path)
+        yaml = Yaml(self._file_path)
         self._yaml_content = yaml.content
         return self._yaml_content

--- a/rpmlb/yaml.py
+++ b/rpmlb/yaml.py
@@ -34,7 +34,6 @@ class Yaml:
 
     @staticmethod
     def run_cmd_element(cmd_element, **kwargs):
-        cmds = None
         if isinstance(cmd_element, str):
             cmds = [cmd_element]
         elif isinstance(cmd_element, list):

--- a/rpmlb/yaml.py
+++ b/rpmlb/yaml.py
@@ -3,6 +3,8 @@ import os
 
 import yaml
 
+from . import utils
+
 LOG = logging.getLogger(__name__)
 
 
@@ -29,3 +31,18 @@ class Yaml:
         output = yaml.dump(self.content, Dumper=Dumper,
                            default_flow_style=False)
         print(output)
+
+    @staticmethod
+    def run_cmd_element(cmd_element, **kwargs):
+        cmds = None
+        if isinstance(cmd_element, str):
+            cmds = [cmd_element]
+        elif isinstance(cmd_element, list):
+            cmds = cmd_element
+        else:
+            message = 'Invalid type of cmd_element: {!r}'.format(
+                type(cmd_element)
+            )
+            raise ValueError(message)
+        for cmd in cmds:
+            utils.run_cmd(cmd, **kwargs)

--- a/tests/fixtures/custom/rhpkg_internal_copr.yml
+++ b/tests/fixtures/custom/rhpkg_internal_copr.yml
@@ -18,11 +18,6 @@ build:
         sed -i 's/rh-nodejs6/rh-nodejs4/g' rh-ror50.spec
         sed -i 's/rh-mongodb32/rh-mongodb26/g' rh-ror50.spec
     fi
-  - | # Hack around flexmock bootstrap
-    if [ "$(basename $(realpath ..))" = "009" ]; then
-        sed -i '/^BuildRequires.*rubygem(rspec)$/ s/^/#/' rubygem-flexmock.spec
-        sed -i '/^%check$/,/^popd$/ s/^/#/' rubygem-flexmock.spec
-    fi
   - | # Hack around railties dependency
     if [ "${PKG}" = "rubygem-railties" ]; then
         sed -i '/^patch -p2 < %{PATCH2}$/ s/^/#/' rubygem-railties.spec

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,7 +1,11 @@
 import os
+import random
 import shutil
 import tempfile
 from contextlib import contextmanager
+
+TMP_FILE_PREFIX = 'rpmlb-tmp-'
+RANDOM_BITS = 32
 
 
 def touch(path):
@@ -23,9 +27,30 @@ def pushd(new_dir):
 def pushd_tmp_dir():
     tmp_dir = None
     try:
-        tmp_dir = tempfile.mkdtemp(prefix='rpmlb-tmp-')
+        tmp_dir = tempfile.mkdtemp(prefix=TMP_FILE_PREFIX)
         with pushd(tmp_dir):
             yield
     finally:
         if os.path.isdir(tmp_dir):
             shutil.rmtree(tmp_dir)
+
+
+def get_random_generated_tmp_file():
+    random_bits = random.getrandbits(RANDOM_BITS)
+    random_hash = '%x' % random_bits
+    tmp_file = os.path.join(tempfile.gettempdir(),
+                            TMP_FILE_PREFIX + random_hash)
+    return tmp_file
+
+
+def remove_if_is_file(file):
+    if os.path.isfile(file):
+        os.remove(file)
+
+
+def get_valid_recipe_file():
+    return 'tests/fixtures/recipes/ror.yml'
+
+
+def get_valid_custom_file():
+    return 'tests/fixtures/custom/echo.yml'

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 
 import pytest
 
@@ -23,16 +24,14 @@ def test_run_cmds_runs_cmds_on_valid_custom_file(valid_custom):
         random_file_foo = helper.get_random_generated_tmp_file()
         random_file_bar_part = helper.get_random_generated_tmp_file()
 
-        def _get_yaml_content(*args):
-            content = {
-                'build': [
-                    'touch {0}'.format(random_file_foo),
-                    'touch "{0}-$PKG"'.format(random_file_bar_part),
-                ]
-            }
-            return content
-
-        valid_custom._get_yaml_content = _get_yaml_content
+        content = {
+            'build': [
+                'touch {0}'.format(random_file_foo),
+                'touch "{0}-$PKG"'.format(random_file_bar_part),
+            ]
+        }
+        type(valid_custom).yaml_content = mock.PropertyMock(
+                                          return_value=content)
 
         valid_custom.run_cmds('build', name='rubygem-bar')
 
@@ -51,15 +50,13 @@ def test_run_cmds_skips_cmds_on_unknown_key(valid_custom):
     try:
         random_file_foo = helper.get_random_generated_tmp_file()
 
-        def _get_yaml_content(*args):
-            content = {
-                'build': [
-                    'touch {0}'.format(random_file_foo),
-                ]
-            }
-            return content
-
-        valid_custom._get_yaml_content = _get_yaml_content
+        content = {
+            'build': [
+                'touch {0}'.format(random_file_foo),
+            ]
+        }
+        type(valid_custom).yaml_content = mock.PropertyMock(
+                                          return_value=content)
 
         valid_custom.run_cmds('dummy')
 
@@ -69,12 +66,12 @@ def test_run_cmds_skips_cmds_on_unknown_key(valid_custom):
             os.remove(random_file_foo)
 
 
-def test_get_yaml_content_returns_content(valid_custom):
-    content = valid_custom._get_yaml_content()
+def test_yaml_content_returns_content(valid_custom):
+    content = valid_custom.yaml_content
     assert content
 
 
-def test_get_yaml_content_returns_singleton_object(valid_custom):
-    content = valid_custom._get_yaml_content()
-    content2 = valid_custom._get_yaml_content()
+def test_yaml_content_returns_singleton_object(valid_custom):
+    content = valid_custom.yaml_content
+    content2 = valid_custom.yaml_content
     assert content is content2

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -1,0 +1,80 @@
+import os
+
+import pytest
+
+import helper
+from rpmlb.custom import Custom
+
+
+@pytest.fixture
+def valid_custom():
+    """A Custom object with a valid custom file."""
+    return Custom(helper.get_valid_custom_file())
+
+
+def test_init_loads_file(valid_custom):
+    assert valid_custom
+
+
+def test_run_cmds_runs_cmds_on_valid_custom_file(valid_custom):
+    random_file_foo = None
+    random_file_bar = None
+    try:
+        random_file_foo = helper.get_random_generated_tmp_file()
+        random_file_bar_part = helper.get_random_generated_tmp_file()
+
+        def _get_yaml_content(*args):
+            content = {
+                'build': [
+                    'touch {0}'.format(random_file_foo),
+                    'touch "{0}-$PKG"'.format(random_file_bar_part),
+                ]
+            }
+            return content
+
+        valid_custom._get_yaml_content = _get_yaml_content
+
+        valid_custom.run_cmds('build', name='rubygem-bar')
+
+        assert os.path.isfile(random_file_foo)
+        random_file_bar = random_file_bar_part + '-rubygem-bar'
+        assert os.path.isfile(random_file_bar)
+    finally:
+        if os.path.isfile(random_file_foo):
+            os.remove(random_file_foo)
+        if os.path.isfile(random_file_bar):
+            os.remove(random_file_bar)
+
+
+def test_run_cmds_skips_cmds_on_unknown_key(valid_custom):
+    random_file_foo = None
+    try:
+        random_file_foo = helper.get_random_generated_tmp_file()
+
+        def _get_yaml_content(*args):
+            content = {
+                'build': [
+                    'touch {0}'.format(random_file_foo),
+                ]
+            }
+            return content
+
+        valid_custom._get_yaml_content = _get_yaml_content
+
+        valid_custom.run_cmds('dummy')
+
+        assert not os.path.isfile(random_file_foo)
+    finally:
+        if os.path.isfile(random_file_foo):
+            os.remove(random_file_foo)
+
+
+def test_get_yaml_content_returns_content(valid_custom):
+    content = valid_custom._get_yaml_content()
+    assert content
+
+
+def test_get_yaml_content_returns_singleton_object(valid_custom):
+    content = valid_custom._get_yaml_content()
+    content2 = valid_custom._get_yaml_content()
+    assert content is content2

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -3,12 +3,13 @@ from collections.abc import Mapping
 
 import pytest
 
+import helper
 from rpmlb.recipe import Recipe
 
 
 @pytest.fixture
 def ok_recipe():
-    return Recipe('tests/fixtures/recipes/ror.yml', 'rh-ror50')
+    return Recipe(helper.get_valid_recipe_file(), 'rh-ror50')
 
 
 @pytest.fixture
@@ -60,7 +61,7 @@ def test_recipe(ok_recipe):
 
 def test_recipe_not_found():
     with pytest.raises(KeyError):
-        Recipe('tests/fixtures/recipes/ror.yml', 'dummy')
+        Recipe(helper.get_valid_recipe_file(), 'dummy')
 
 
 def test_verify_returns_true_on_valid_recipe(ok_recipe):

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,0 +1,70 @@
+import os
+
+import pytest
+
+import helper
+from rpmlb.yaml import Yaml
+
+
+@pytest.fixture
+def valid_yaml():
+    """A Yaml object with a valid YAML file."""
+    return Yaml(helper.get_valid_recipe_file())
+
+
+def test_init_loads_file(valid_yaml):
+    assert valid_yaml
+
+
+def test_init_raises_error_on_not_existing_file():
+    with pytest.raises(FileNotFoundError):
+        Yaml('foo/dummy.yml')
+
+
+def test_dump_prints_output(capsys, valid_yaml):
+    valid_yaml.dump()
+    stdout, stderr = capsys.readouterr()
+    assert 'rh-ror50:' in stdout
+
+
+def test_run_cmds_runs_cmd_by_cmd_element_type_string():
+    # Test with generated file.
+    # Because we can not test using stdout with capsys fixture,
+    # the capsys does not capture stdout from subprocess in run_cmds.
+    random_file = helper.get_random_generated_tmp_file()
+    try:
+        cmd_element = "touch {0}".format(random_file)
+        Yaml.run_cmd_element(cmd_element)
+        assert os.path.isfile(random_file)
+    finally:
+        helper.remove_if_is_file(random_file)
+
+
+def test_run_cmds_runs_cmds_by_cmd_element_type_list():
+    random_file_foo = helper.get_random_generated_tmp_file()
+    random_file_bar_part = helper.get_random_generated_tmp_file()
+    random_file_bar = random_file_bar_part + '-bar'
+    try:
+
+        cmd_element = [
+            'touch {0}'.format(random_file_foo),
+            'touch "{0}-$BAR"'.format(random_file_bar_part),
+        ]
+        env = {
+            'BAR': 'bar'
+        }
+        Yaml.run_cmd_element(cmd_element, env=env)
+
+        assert os.path.isfile(random_file_foo)
+        assert os.path.isfile(random_file_bar)
+    finally:
+        helper.remove_if_is_file(random_file_foo)
+        helper.remove_if_is_file(random_file_bar)
+
+
+def test_run_cmds_raises_error_on_cmd_element_type_dict():
+    cmd_element = {
+        'a': 'b'
+    }
+    with pytest.raises(ValueError):
+        Yaml.run_cmd_element(cmd_element)


### PR DESCRIPTION
This fixes https://github.com/sclorg/rpm-list-builder/issues/20

Just in case I also did below test with modified `ror.yml` recipe (See latest 1 commit): https://github.com/junaruga/rhscl-rebuild-recipes/commits/feature/ror-cmd-element .
 
https://github.com/sclorg/rpm-list-builder/wiki/Example-to-build-with-Copr-for-Ruby-on-Rails-recipe

```
$ rpmlb \
  --download custom \
  --build custom \
  --custom-file tests/fixtures/custom/rhpkg_internal_copr.yml \
  --work-directory $HOME/tmp/rpmlb_work_dir \
  ../rhscl-rebuild-recipes/ror.yml \
  rh-ror50 2>&1 | tee rpmlb.log
```

The `cmd` element is for a recipe file.
But I also modified `custom.py`  file for `custom` download/build mode.
Because I wanted to use the common logic to call commands in YAML file for from Recipe and Custom file logic.


