### PR TITLE
Add --version option

### DIFF
--- a/rpmlb/cli.py
+++ b/rpmlb/cli.py
@@ -15,6 +15,7 @@ from .work import Work
 @click.command(add_help_option=False)
 # General options
 @click.help_option('--help', '-h')  # Enable short help switch (-h)
+@click.version_option()
 @click.option(
     '--verbose', '-v', is_flag=True, default=False,
     help='Turn on verbose logging.',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -194,3 +194,14 @@ def test_help_option_variants(runner, help_switch, recipe_arguments):
     result = runner.invoke(run, [help_switch] + recipe_arguments)
 
     assert result.exit_code == 0, result.output
+
+
+@pytest.mark.parametrize('version_switch', ['--version'])
+def test_version_option(runner, version_switch):
+    """Test that --version option displays the version"""
+    result = runner.invoke(run, [version_switch])
+    out = result.output.strip()
+
+    assert result.exit_code == 0
+    assert len(out.split('\n')) == 1
+    assert 'version' in out


### PR DESCRIPTION
The current version is automatically detected using setuptools.

Output:
```
$ python -m rpmlb --version
rpmlb, version 1.0.0
```