### PR TITLE
Reference RHSCL Rebuild Recipes

### DIFF
--- a/docs/users_guide.md
+++ b/docs/users_guide.md
@@ -3,6 +3,8 @@
 This document is to explain use case with actual command line.
 About the example, you can refer an integration test script [tests/integration/run.sh](../tests/integration/run.sh) test_foo method too.
 
+For documentation on the recipe file format, see the [RHSCL Rebuild Recipes](https://github.com/sclorg/rhscl-rebuild-recipes).
+
 ## Architecture
 
 The application is to help building a list of RPM packages.


### PR DESCRIPTION
The RHSCL Rebuild Recipe README has some useful docs
for the recipe file format, so this adds a cross-reference from
the user guide.