### PR TITLE
Koji hotfixes

### DIFF
--- a/rpmlb/builder/koji.py
+++ b/rpmlb/builder/koji.py
@@ -180,7 +180,12 @@ class KojiBuilder(BaseBuilder):
 
         run_cmd_with_capture(' '.join(command))
 
-        srpm_path, = cwd.glob('{collection}-{name}-*.src.rpm'.format(
+        if name == collection:  # metapackage build
+            glob_format = '{collection}-*.src.rpm'
+        else:
+            glob_format = '{collection}-{name}-*.src.rpm'
+
+        srpm_path, = cwd.glob(glob_format.format(
             collection=collection,
             name=name,
         ))

--- a/rpmlb/builder/koji.py
+++ b/rpmlb/builder/koji.py
@@ -21,13 +21,16 @@ class KojiBuilder(BaseBuilder):
         koji_scratch: bool = False,
         koji_epel: int = None,
         koji_target_format: str = DEFAULT_TARGET_FORMAT,
-        koji_profile: Optional[str] = None
+        koji_profile: Optional[str] = None,
+        **extra_options
     ):
         """Initialize the builder.
 
         Keyword arguments:
             work: Overview of the work to do.
-            epel: Version number of the EPEL to build for.
+            koji_scratch: Indicates if the --scratch build option
+                should be used.
+            koji_epel: Version number of the EPEL to build for.
             koji_target_format: Format string for the target to build into.
             koji_profile: Name of the configuration profile to use.
         """

--- a/rpmlb/builder/koji.py
+++ b/rpmlb/builder/koji.py
@@ -1,5 +1,6 @@
 """Builder interface for the Koji build service."""
 
+import logging
 import re
 from pathlib import Path
 from typing import Iterator, Optional, Sequence
@@ -7,6 +8,8 @@ from typing import Iterator, Optional, Sequence
 from ..utils import run_cmd, run_cmd_with_capture
 from ..work import Work
 from .base import BaseBuilder
+
+LOG = logging.getLogger(__name__)
 
 
 class KojiBuilder(BaseBuilder):
@@ -21,6 +24,7 @@ class KojiBuilder(BaseBuilder):
         koji_scratch: bool = False,
         koji_epel: int = None,
         koji_target_format: str = None,
+        koji_owner: str = None,
         koji_profile: Optional[str] = None,
         **extra_options
     ):
@@ -32,12 +36,16 @@ class KojiBuilder(BaseBuilder):
                 should be used.
             koji_epel: Version number of the EPEL to build for.
             koji_target_format: Format string for the target to build into.
+            koji_owner: The user name of the owner of packages
+                newly added to a build tag.
             koji_profile: Name of the configuration profile to use.
         """
 
         # Validity checks
         if koji_epel is None:
             raise ValueError('koji_epel parameter is required.')
+        if koji_owner is None:
+            raise ValueError('koji_owner parameter is required.')
 
         #: The collection to build
         self.collection = work._recipe._collection_id
@@ -48,11 +56,17 @@ class KojiBuilder(BaseBuilder):
         #: Format string for the build target
         self.target_format = koji_target_format or self.DEFAULT_TARGET_FORMAT
 
+        #: Owner of packages added by this builder into a tag
+        self.owner = koji_owner
+
         #: The configuration profile to use
         self.profile = koji_profile
 
         #: Scratch build indicator
         self.scratch_build = koji_scratch
+
+        # Private target destination cache
+        self._destination_tag_cache = {}
 
     @property
     def base_command(self) -> Sequence[str]:
@@ -121,6 +135,11 @@ class KojiBuilder(BaseBuilder):
             collection=self.collection,
             epel=self.epel,
         )
+
+        self._add_package(name='{collection}-{name}'.format(
+            collection=self.collection,
+            name=package_dict['name'],
+        ))
         self._submit_build(srpm_path)
         self._wait_for_repo()
 
@@ -166,6 +185,46 @@ class KojiBuilder(BaseBuilder):
             name=name,
         ))
         return srpm_path
+
+    @property
+    def _destination_tag(self) -> str:
+        """Queries the destination tag for a current target."""
+
+        # Destination tag is dependent on target name and profile
+        # Note: extract to generic utility decorator?
+        cache_key = self.profile, self.target
+
+        cached = self._destination_tag_cache.get(cache_key, None)
+        if cached is not None:
+            return cached
+
+        query = ['list-targets', '--name={self.target}'.format(self=self)]
+
+        # FIXME: ugly parsing of koji output
+        raw_output = run_cmd_with_capture(' '.join(self.base_command + query))
+        target_line = raw_output.stdout.splitlines()[2]
+        destination_tag = target_line.split()[-1].decode('utf-8')
+
+        LOG.debug('Destination tag: {}'.format(destination_tag))
+
+        self._destination_tag_cache[cache_key] = destination_tag
+        return destination_tag
+
+    def _add_package(self, name: str) -> None:
+        """Add package to the destination tag for the target.
+
+        Keyword arguments:
+            name: Name of the package to add.
+        """
+
+        # Command is safely ignored if the package is in the tag already
+        command = [
+            'add-pkg',
+            '--owner={owner}'.format(owner=self.owner),
+            self._destination_tag,
+            name,
+        ]
+        run_cmd(' '.join(self.base_command + command))
 
     def _submit_build(self, srpm_path: Path) -> None:
         """Submit build to the build service.

--- a/rpmlb/builder/koji.py
+++ b/rpmlb/builder/koji.py
@@ -20,7 +20,7 @@ class KojiBuilder(BaseBuilder):
         *,
         koji_scratch: bool = False,
         koji_epel: int = None,
-        koji_target_format: str = DEFAULT_TARGET_FORMAT,
+        koji_target_format: str = None,
         koji_profile: Optional[str] = None,
         **extra_options
     ):
@@ -46,7 +46,7 @@ class KojiBuilder(BaseBuilder):
         self.epel = koji_epel
 
         #: Format string for the build target
-        self.target_format = koji_target_format
+        self.target_format = koji_target_format or self.DEFAULT_TARGET_FORMAT
 
         #: The configuration profile to use
         self.profile = koji_profile

--- a/rpmlb/cli.py
+++ b/rpmlb/cli.py
@@ -103,6 +103,10 @@ DIST_RE = re.compile('^(fc|el|centos)[0-9]*$')
     '--koji-scratch', is_flag=True, default=False,
     help='Make scratch builds with koji builder.',
 )
+@click.option(
+    '--koji-owner', metavar='OWNER',
+    help='Owner of packages added by koji builder.',
+)
 # Positional arguments
 @click.argument(
     'recipe_file',

--- a/tests/builder/test_koji.py
+++ b/tests/builder/test_koji.py
@@ -153,6 +153,18 @@ def test_base_command_respect_profile(builder, profile, expected_command):
     assert builder.base_command == expected_command
 
 
+def test_default_format_is_used(work, epel):
+    """Default format is used when no target format is specified."""
+
+    parameters = {
+        'koji_epel': epel,  # required
+        'koji_target_format': None,  # explicit None => should use default
+    }
+
+    builder = KojiBuilder(work, **parameters)
+    assert builder.target_format == KojiBuilder.DEFAULT_TARGET_FORMAT
+
+
 @pytest.mark.parametrize('collection', ['test', 'rh-ror50'])
 def test_target_respects_format(
     builder, target_format, collection, epel

--- a/tests/builder/test_koji.py
+++ b/tests/builder/test_koji.py
@@ -113,6 +113,9 @@ def cli_parameters(target_format, epel, profile, scratch_build):
         'koji_profile': profile,
         'koji_target_format': target_format,
         'koji_scratch': scratch_build,
+
+        # Extra parameter to assure the builder can take them
+        'copr_repo': 'test/example',
     }
 
 

--- a/tests/fixtures/specfiles/metapackage.spec
+++ b/tests/fixtures/specfiles/metapackage.spec
@@ -1,0 +1,84 @@
+# Taken with minor adjustments from https://www.softwarecollections.org/en/docs/guide/#sect-Creating_a_Meta_Package
+
+%global scl_name_prefix rh-
+%global scl_name_base ror
+%global scl_name_version 50
+
+%global scl %{scl_name_prefix}%{scl_name_base}%{scl_name_version}
+
+# Optional but recommended: define nfsmountable
+%global nfsmountable 1
+
+%scl_package %scl
+%global _scl_prefix /opt/rpmlb
+
+Summary: Package that installs %scl
+Name: %scl_name
+Version: 1
+Release: 1%{?dist}
+License: GPLv2+
+Requires: %{scl_prefix}less
+BuildRequires: scl-utils-build
+
+%description
+This is the main package for %scl Software Collection.
+
+%package runtime
+Summary: Package that handles %scl Software Collection.
+Requires: scl-utils
+
+%description runtime
+Package shipping essential scripts to work with %scl Software Collection.
+
+%package build
+Summary: Package shipping basic build configuration
+Requires: scl-utils-build
+
+%description build
+Package shipping essential configuration macros to build %scl Software Collection.
+
+# This is only needed when you want to provide an optional scldevel subpackage
+%package scldevel
+Summary: Package shipping development files for %scl
+
+%description scldevel
+Package shipping development files, especially useful for development of
+packages depending on %scl Software Collection.
+
+%prep
+%setup -c -T
+
+%install
+%scl_install
+
+cat >> %{buildroot}%{_scl_scripts}/enable << EOF
+export PATH="%{_bindir}:%{_sbindir}\${PATH:+:\${PATH}}"
+export LD_LIBRARY_PATH="%{_libdir}\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}"
+export MANPATH="%{_mandir}:\${MANPATH:-}"
+export PKG_CONFIG_PATH="%{_libdir}/pkgconfig\${PKG_CONFIG_PATH:+:\${PKG_CONFIG_PATH}}"
+EOF
+
+# This is only needed when you want to provide an optional scldevel subpackage
+cat >> %{buildroot}%{_root_sysconfdir}/rpm/macros.%{scl_name_base}-scldevel << EOF
+%%scl_%{scl_name_base} %{scl}
+%%scl_prefix_%{scl_name_base} %{scl_prefix}
+EOF
+
+# Install the generated man page
+mkdir -p %{buildroot}%{_mandir}/man7/
+install -p -m 644 %{scl_name}.7 %{buildroot}%{_mandir}/man7/
+
+%files
+
+%files runtime -f filelist
+%scl_files
+
+%files build
+%{_root_sysconfdir}/rpm/macros.%{scl}-config
+
+%files scldevel
+%{_root_sysconfdir}/rpm/macros.%{scl_name_base}-scldevel
+
+%changelog
+* Fri Aug 30 2013 John Doe <jdoe@example.com> 1-1
+- Initial package

--- a/tests/fixtures/specfiles/minimal.spec
+++ b/tests/fixtures/specfiles/minimal.spec
@@ -1,0 +1,26 @@
+%{?scl:%scl_package test}
+%{!?scl:%global pkg_name %{name}}
+
+Name:       %{?scl_prefix}test
+Version:    1.0
+Release:    1%{?dist}
+Summary:    Minimal spec for testing purposes
+
+Group:      Development/Testing
+License:    MIT
+URL:        http://test.example.com
+
+%description
+A minimal SPEC file for testing of RPM packaging.
+
+%prep
+
+%build
+
+%install
+
+%files
+
+%changelog
+* Thu Jun 22 2017 Jan Stanek <jstanek@redhat.com> 1.0-1
+- Initial package


### PR DESCRIPTION
Fixes for two issues found when trying to rebuild `rh-ror50` with `KojiBuilder`:

* The `target_format` should be set to default value even when the `koji_target_format` is *explicitly* set to None
* `__init__` should accept (and ignore) arbitrary keyword arguments.

Tests triggering those two issues are included.