### PR TITLE
Set CUSTOM_DIR environment variable

### DIFF
--- a/docs/users_guide.md
+++ b/docs/users_guide.md
@@ -196,7 +196,8 @@ work_directory/
   * `before_download`: Write commands to run before build.
   * `download`: Write commands to run for each packages in the pacakges directory. You can use environment variable `PKG` to describe the package name.
 
-
+For both hooks, the environment variable `CUSTOM_DIR` refers to the directory containing the custom file
+(allowing configuration files and helper scripts to be located relative to it).
 
 ### Specify work directory
 
@@ -258,6 +259,9 @@ work_directory/
 
   * `before_build`: Write commands to run before build.
   * `build`: Write commands to run for each packages in the pacakges directory. You can use environment variable `PKG` to describe the package name.
+
+For both hooks, the environment variable `CUSTOM_DIR` refers to the directory containing the custom file
+(allowing configuration files and helper scripts to be located relative to it).
 
 #### Don't build
 

--- a/rpmlb/custom.py
+++ b/rpmlb/custom.py
@@ -1,4 +1,5 @@
 import logging
+import os.path
 
 from rpmlb.yaml import Yaml
 
@@ -9,7 +10,8 @@ class Custom:
     """A class to manage custom file."""
 
     def __init__(self, file_path):
-        self._file_path = file_path
+        self._file_path = file_path = os.path.abspath(str(file_path))
+        self._custom_dir = os.path.dirname(file_path)
         self._yaml_content = None
 
     def run_cmds(self, key, **kwargs):
@@ -23,6 +25,7 @@ class Custom:
             return
         cmd_element = cmd_dict[key]
 
+        env['CUSTOM_DIR'] = self._custom_dir
         Yaml.run_cmd_element(cmd_element, env=env)
 
     @property

--- a/tests/builder/test_custom.py
+++ b/tests/builder/test_custom.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+from subprocess import STDOUT, check_output
+
+# These tests use subprocess directly due to weird interactions with test_cli
+# that lead to the command output being unreliable when using click.CliRunner.
+
+_TEST_DIR = Path(__file__).parent.parent
+_CUSTOM_HOOK_DIR = _TEST_DIR / "fixtures" / "custom"
+_CUSTOM_HOOKS = _CUSTOM_HOOK_DIR / "echo.yml"
+_EXAMPLE_RECIPE = _TEST_DIR / "fixtures" / "recipes" / "echo_recipe.yml"
+
+# The custom echo backend is fast enough & simple enough that we just run a
+# full end-to-end integration test as the custom builder's unit tests
+#
+# Both the download & build hooks need to be run, or the latter fail due to
+# the missing package directories
+
+_cli_command = [
+    "rpmlb", "--custom-file", str(_CUSTOM_HOOKS),
+    "--download", "custom", "--build", "custom",
+    str(_EXAMPLE_RECIPE), "echo-packages",
+]
+
+
+def test_custom_build_hooks():
+    """Test that `--build custom` works as expected"""
+    output = check_output(_cli_command, universal_newlines=True, stderr=STDOUT)
+    lines = output.strip().splitlines()
+    # Only a unit test, so we don't explicitly check hook order,
+    # just the expected implicit environment variable declarations
+    hook_dir_line = "Using hook dir: {}".format(_CUSTOM_HOOK_DIR)
+    package_1_build_line = "Building PKG: a-package"
+    package_2_build_line = "Building PKG: another-package"
+    assert hook_dir_line in lines
+    assert package_1_build_line in lines
+    assert package_2_build_line in lines

--- a/tests/fixtures/custom/echo.yml
+++ b/tests/fixtures/custom/echo.yml
@@ -1,19 +1,26 @@
 before_download:
   - echo "This command is run before download."
-  - pwd
+  - |
+    echo "Using hook dir: ${CUSTOM_DIR}"
+    echo "Running hook in:" $(pwd)
 download:
   - echo "This command is run for each package download."
   - |
+    echo "Using hook dir: ${CUSTOM_DIR}"
+    echo "Running hook in:" $(pwd)
     echo "Downloading PKG: ${PKG}"
     if [ "${PKG}" != "" ]; then
         mkdir "${PKG}"
         touch "${PKG}/${PKG}.spec"
     fi
-  - pwd
 before_build:
   - echo "This command is run before build."
-  - pwd
+  - |
+    echo "Using hook dir: ${CUSTOM_DIR}"
+    echo "Running hook in:" $(pwd)
 build:
   - echo "This command is run for each package build."
-  - "echo Building PKG: ${PKG}"
-  - pwd
+  - |
+    echo "Using hook dir: ${CUSTOM_DIR}"
+    echo "Running hook in:" $(pwd)
+    echo "Building PKG: ${PKG}"

--- a/tests/fixtures/recipes/echo_recipe.yml
+++ b/tests/fixtures/recipes/echo_recipe.yml
@@ -1,0 +1,8 @@
+# Example recipe designed solely for use with the custom echo backend
+---
+echo-packages:
+  name: Echo Packages
+  packages:
+    - a-package
+    - another-package
+    - a-package # Deliberately repeated


### PR DESCRIPTION
This allows configuration files and helper scripts to be
located relative to the custom hook file that needs them.

For example, an uninstalled mock configuration file can be
referenced as `mock -r ${CUSTOM_DIR}/custom-mock.cfg ...`.

Closes #67 