### PR TITLE
Revert monkeypatches in test_custom

### DIFF
--- a/rpmlb/yaml.py
+++ b/rpmlb/yaml.py
@@ -17,7 +17,7 @@ class Yaml:
         except ImportError:
             from yaml import Loader
         try:
-            with open(file_path, 'r') as stream:
+            with open(str(file_path), 'r') as stream:
                 self.content = yaml.load(stream, Loader=Loader)
         except FileNotFoundError as e:
             LOG.error('File not found: %s at %s', file_path, os.getcwd())

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -15,7 +15,7 @@ def test_init_loads_file(valid_custom):
     assert valid_custom
 
 
-def test_run_cmds_runs_cmds_on_valid_custom_file(valid_custom):
+def test_run_cmds_runs_cmds_on_valid_custom_file(valid_custom, monkeypatch):
     with pytest.helpers.generate_tmp_path_list(2) as tmp_paths:
         random_file_foo, random_file_bar_part = tmp_paths
 
@@ -25,9 +25,8 @@ def test_run_cmds_runs_cmds_on_valid_custom_file(valid_custom):
                 'touch "{0!s}-$PKG"'.format(random_file_bar_part),
             ]
         }
-        type(valid_custom).yaml_content = mock.PropertyMock(
-            return_value=content,
-        )
+        monkeypatch.setattr(type(valid_custom), 'yaml_content',
+                            mock.PropertyMock(return_value=content))
 
         valid_custom.run_cmds('build', name='rubygem-bar')
 
@@ -39,15 +38,15 @@ def test_run_cmds_runs_cmds_on_valid_custom_file(valid_custom):
         assert random_file_bar.is_file()
 
 
-def test_run_cmds_skips_cmds_on_unknown_key(valid_custom, random_file_path):
+def test_run_cmds_skips_cmds_on_unknown_key(valid_custom, random_file_path,
+                                            monkeypatch):
     content = {
         'build': [
             'touch {0!s}'.format(random_file_path),
         ]
     }
-    type(valid_custom).yaml_content = mock.PropertyMock(
-        return_value=content,
-    )
+    monkeypatch.setattr(type(valid_custom), 'yaml_content',
+                        mock.PropertyMock(return_value=content))
 
     valid_custom.run_cmds('dummy')
 


### PR DESCRIPTION
Uses the pytest monkeypatch fixture to ensure that
changes to the Custom class are reverted after the
relevant tests.