### PR TITLE
Remove hardcoded "rhpkg".

### DIFF
--- a/rpmlb/builder/base.py
+++ b/rpmlb/builder/base.py
@@ -35,6 +35,9 @@ class BaseBuilder:
             work: Overview of the work to do.
             options: Command line options for the builder to process.
         """
+        if 'pkg_cmd' not in options:
+            raise ValueError('pkg_cmd is required.')
+        self._pkg_cmd = options['pkg_cmd']
 
     @staticmethod
     def get_instance(name: str, work: Work, **options):

--- a/rpmlb/builder/copr.py
+++ b/rpmlb/builder/copr.py
@@ -27,7 +27,6 @@ class CoprBuilder(BaseBuilder):
         self.copr_repo = copr_repo
 
     def build(self, package_dict, **kwargs):
-
         utils.run_cmd('rm -v *.rpm', check=False)
-        utils.run_cmd('rhpkg srpm')
-        utils.run_cmd('copr-cli build %s *.rpm' % self.copr_repo)
+        utils.run_cmd('{} srpm'.format(self._pkg_cmd))
+        utils.run_cmd('copr-cli build {} *.rpm'.format(self.copr_repo))

--- a/rpmlb/builder/mock.py
+++ b/rpmlb/builder/mock.py
@@ -27,11 +27,9 @@ class MockBuilder(BaseBuilder):
         self.mock_config = mock_config
 
     def before(self, work, **kwargs):
-
-        utils.run_cmd('mock -r %s --scrub=all' % self.mock_config)
+        utils.run_cmd('mock -r {} --scrub=all'.format(self.mock_config))
 
     def build(self, package_dict, **kwargs):
-
         utils.run_cmd('rm -v *.rpm', check=False)
-        utils.run_cmd('rhpkg srpm')
-        utils.run_cmd('mock -r %s -n *.rpm' % self.mock_config)
+        utils.run_cmd('{} srpm'.format(self._pkg_cmd))
+        utils.run_cmd('mock -r {} -n *.rpm'.format(self.mock_config))

--- a/rpmlb/cli.py
+++ b/rpmlb/cli.py
@@ -29,7 +29,7 @@ DIST_RE = re.compile('^(fc|el|centos)[0-9]*$')
 )
 @click.option(
     '--download', '-d',
-    type=click.Choice('none local rhpkg custom'.split()),
+    type=click.Choice('none local fedpkg rhpkg custom'.split()),
     default='none',
     help='Choose a download type.',
 )
@@ -59,7 +59,8 @@ DIST_RE = re.compile('^(fc|el|centos)[0-9]*$')
 # Download options
 @click.option(
     '--branch', '-B', metavar='BRANCH',
-    help='Git branch for downloaders that use it (rhpkg).',
+    help=('Git branch for downloaders that use it '
+          '(download type: fedpkg, rhpkg).'),
 )
 @click.option(
     '--source-directory', '-S', metavar='SOURCE_DIRECTORY',
@@ -72,6 +73,12 @@ DIST_RE = re.compile('^(fc|el|centos)[0-9]*$')
     '--resume', '-r', metavar='RESUME',
     type=click.INT,
     help='Resume build from specified position.',
+)
+@click.option(
+    '--pkg-cmd',
+    type=click.Choice('fedpkg rhpkg'.split()),
+    default='fedpkg',
+    help='Choose a package command.',
 )
 @click.option(
     '--mock-config', '-M', metavar='MOCK_CONFIG',
@@ -110,6 +117,8 @@ def run(recipe_file, collection_id, **option_dict):
 
     log = logging.getLogger(__name__)
 
+    _adjust_option_dict(option_dict)
+
     # Load recipe and processing objects
     recipe = Recipe(recipe_file, collection_id)
     recipe.verify()
@@ -141,3 +150,15 @@ def validate_dist(dist):
         raise click.BadParameter(
             'dist shoule be match to pattern {0}'.format(DIST_RE.pattern))
     return dist
+
+
+def _adjust_option_dict(option_dict):
+    if not option_dict:
+        return
+    download = option_dict.get('download', None)
+    # When specifying download type: fedpkg or rhpkg,
+    # users must want to use the command in Builder.
+    for download_type in ('fedpkg', 'rhpkg'):
+        if download_type == download:
+            option_dict['pkg_cmd'] = download_type
+            break

--- a/rpmlb/cli.py
+++ b/rpmlb/cli.py
@@ -77,7 +77,6 @@ DIST_RE = re.compile('^(fc|el|centos)[0-9]*$')
 @click.option(
     '--pkg-cmd',
     type=click.Choice('fedpkg rhpkg'.split()),
-    default='fedpkg',
     help='Choose a package command.',
 )
 @click.option(
@@ -117,7 +116,7 @@ def run(recipe_file, collection_id, **option_dict):
 
     log = logging.getLogger(__name__)
 
-    _adjust_option_dict(option_dict)
+    _choose_pkg_cmd(option_dict)
 
     # Load recipe and processing objects
     recipe = Recipe(recipe_file, collection_id)
@@ -152,13 +151,17 @@ def validate_dist(dist):
     return dist
 
 
-def _adjust_option_dict(option_dict):
+def _choose_pkg_cmd(option_dict):
     if not option_dict:
         return
+    # User chose the command explicitly.
+    if 'pkg_cmd' in option_dict and option_dict['pkg_cmd']:
+        return
+
+    # Set default value.
+    option_dict['pkg_cmd'] = 'fedpkg'
+
     download = option_dict.get('download', None)
-    # When specifying download type: fedpkg or rhpkg,
-    # users must want to use the command in Builder.
-    for download_type in ('fedpkg', 'rhpkg'):
-        if download_type == download:
-            option_dict['pkg_cmd'] = download_type
-            break
+    # No explicit command, but relevant builder was selected.
+    if download in ('fedpkg', 'rhpkg'):
+        option_dict['pkg_cmd'] = download

--- a/rpmlb/downloader/base_rpkg.py
+++ b/rpmlb/downloader/base_rpkg.py
@@ -9,6 +9,7 @@ LOG = logging.getLogger(__name__)
 class BaseRpkgDownloader(BaseDownloader):
     """A downloader class to get a pacakge with package command."""
 
+    @property
     def command(self):
         raise NotImplementedError('Implement this method.')
 
@@ -19,11 +20,10 @@ class BaseRpkgDownloader(BaseDownloader):
             raise ValueError('branch is required.')
         branch = kwargs['branch']
 
-        package_command = self.command()
         package = package_dict['name']
         cmd = r'''
 {} co {} && \
 cd {} && \
 git checkout {}
-        '''.strip().format(package_command, package, package, branch)
+        '''.strip().format(self.command, package, package, branch)
         utils.run_cmd(cmd)

--- a/rpmlb/downloader/base_rpkg.py
+++ b/rpmlb/downloader/base_rpkg.py
@@ -1,0 +1,29 @@
+import logging
+
+from .. import utils
+from .base import BaseDownloader
+
+LOG = logging.getLogger(__name__)
+
+
+class BaseRpkgDownloader(BaseDownloader):
+    """A downloader class to get a pacakge with package command."""
+
+    def command(self):
+        raise NotImplementedError('Implement this method.')
+
+    def download(self, package_dict, **kwargs):
+        if not package_dict:
+            raise ValueError('package_dict is required.')
+        if 'branch' not in kwargs or not kwargs['branch']:
+            raise ValueError('branch is required.')
+        branch = kwargs['branch']
+
+        package_command = self.command()
+        package = package_dict['name']
+        cmd = r'''
+{} co {} && \
+cd {} && \
+git checkout {}
+        '''.strip().format(package_command, package, package, branch)
+        utils.run_cmd(cmd)

--- a/rpmlb/downloader/fedpkg.py
+++ b/rpmlb/downloader/fedpkg.py
@@ -2,5 +2,4 @@ from .base_rpkg import BaseRpkgDownloader
 
 
 class FedpkgDownloader(BaseRpkgDownloader):
-    def command(self):
-        return 'fedpkg'
+    command = 'fedpkg'

--- a/rpmlb/downloader/fedpkg.py
+++ b/rpmlb/downloader/fedpkg.py
@@ -1,0 +1,6 @@
+from .base_rpkg import BaseRpkgDownloader
+
+
+class FedpkgDownloader(BaseRpkgDownloader):
+    def command(self):
+        return 'fedpkg'

--- a/rpmlb/downloader/rhpkg.py
+++ b/rpmlb/downloader/rhpkg.py
@@ -2,5 +2,4 @@ from .base_rpkg import BaseRpkgDownloader
 
 
 class RhpkgDownloader(BaseRpkgDownloader):
-    def command(self):
-        return 'rhpkg'
+    command = 'rhpkg'

--- a/rpmlb/downloader/rhpkg.py
+++ b/rpmlb/downloader/rhpkg.py
@@ -1,35 +1,6 @@
-import logging
-import os
-import subprocess
-
-from rpmlb.downloader.base import BaseDownloader
-
-LOG = logging.getLogger(__name__)
+from .base_rpkg import BaseRpkgDownloader
 
 
-class RhpkgDownloader(BaseDownloader):
-    """A downloader class to get a pacakge with rhpkg command."""
-
-    def download(self, package_dict, **kwargs):
-        if not package_dict:
-            raise ValueError('package_dict is required.')
-        if 'branch' not in kwargs or not kwargs['branch']:
-            raise ValueError('branch is required.')
-        branch = kwargs['branch']
-
-        self.do_rhpkg_and_checkout(package_dict, branch)
-
-    def do_rhpkg_and_checkout(self, package_dict, branch):
-        if not package_dict:
-            raise ValueError('package_dict is required.')
-        if not branch:
-            raise ValueError('branch is required.')
-
-        package = package_dict['name']
-
-        LOG.debug('rhpkg co %s', package)
-        subprocess.check_call(['rhpkg', 'co', package])
-        LOG.debug('cd %s', package)
-        os.chdir(package)
-        LOG.debug('git checkout %s', branch)
-        subprocess.check_call(['git', 'checkout', branch])
+class RhpkgDownloader(BaseRpkgDownloader):
+    def command(self):
+        return 'rhpkg'

--- a/tests/builder/test_base.py
+++ b/tests/builder/test_base.py
@@ -63,12 +63,19 @@ def builder(valid_recipe_path):
 
     recipe = Recipe(str(valid_recipe_path), 'rh-ror50')
     work = Work(recipe)
-    builder = BaseBuilder(work)
+    builder = BaseBuilder(work, pkg_cmd='testpkg')
     return builder
 
 
 def test_init(builder):
     assert builder
+
+
+def test_init_raises_error_without_pkg_cmd_option(valid_recipe_path):
+    recipe = Recipe(str(valid_recipe_path), 'rh-ror50')
+    work = Work(recipe)
+    with pytest.raises(ValueError):
+        BaseBuilder(work)
 
 
 def test_run_calls_before_build_after(builder):

--- a/tests/builder/test_copr.py
+++ b/tests/builder/test_copr.py
@@ -1,0 +1,43 @@
+from unittest import mock
+
+import pytest
+
+from rpmlb.builder.copr import CoprBuilder
+from rpmlb.recipe import Recipe
+from rpmlb.work import Work
+
+
+@pytest.fixture
+def work(valid_recipe_path):
+    """Provide Work instance."""
+
+    valid_recipe = Recipe(str(valid_recipe_path), 'rh-ror50')
+    return Work(valid_recipe)
+
+
+@pytest.fixture
+def builder(work):
+    pkg_cmd = 'fedpkg'
+    copr_repo = 'ror50-test'
+    return CoprBuilder(work, pkg_cmd=pkg_cmd, copr_repo=copr_repo)
+
+
+def test_init(builder):
+    assert builder
+
+
+def test_init_raises_error_without_copr_repo(builder):
+    pkg_cmd = 'fedpkg'
+    with pytest.raises(ValueError):
+        CoprBuilder(work, pkg_cmd=pkg_cmd)
+
+
+def test_build_passes(builder, work):
+    with mock.patch('rpmlb.utils.run_cmd',
+                    mock.Mock(return_value=True)) as mock_run_cmd:
+        package_dict = {'name': 'a'}
+        builder.build(package_dict)
+        mock_run_cmd.assert_any_call('rm -v *.rpm', check=False)
+        mock_run_cmd.assert_any_call('fedpkg srpm')
+        mock_run_cmd.assert_any_call('copr-cli build ror50-test *.rpm')
+    assert True

--- a/tests/builder/test_mock.py
+++ b/tests/builder/test_mock.py
@@ -1,0 +1,50 @@
+from unittest import mock
+
+import pytest
+
+from rpmlb.builder.mock import MockBuilder
+from rpmlb.recipe import Recipe
+from rpmlb.work import Work
+
+
+@pytest.fixture
+def work(valid_recipe_path):
+    """Provide Work instance."""
+
+    valid_recipe = Recipe(str(valid_recipe_path), 'rh-ror50')
+    return Work(valid_recipe)
+
+
+@pytest.fixture
+def builder(work):
+    pkg_cmd = 'fedpkg'
+    mock_config = 'fedora-rawhide-x86_64'
+    return MockBuilder(work, pkg_cmd=pkg_cmd, mock_config=mock_config)
+
+
+def test_init(builder):
+    assert builder
+
+
+def test_init_raises_error_without_mock_config(builder):
+    pkg_cmd = 'fedpkg'
+    with pytest.raises(ValueError):
+        MockBuilder(work, pkg_cmd=pkg_cmd)
+
+
+def test_before_passes(builder, work):
+    with mock.patch('rpmlb.utils.run_cmd', mock.Mock(return_value=True)):
+        builder.before(work)
+    assert True
+
+
+def test_build_passes(builder, work):
+    with mock.patch('rpmlb.utils.run_cmd',
+                    mock.Mock(return_value=True)) as mock_run_cmd:
+        package_dict = {'name': 'a'}
+        builder.build(package_dict)
+        mock_run_cmd.assert_any_call('rm -v *.rpm', check=False)
+        mock_run_cmd.assert_any_call('fedpkg srpm')
+        mock_run_cmd.assert_any_call('mock -r fedora-rawhide-x86_64 -n *.rpm')
+
+    assert True

--- a/tests/downloader/test_base_rpkg.py
+++ b/tests/downloader/test_base_rpkg.py
@@ -1,0 +1,54 @@
+from unittest import mock
+
+import pytest
+
+from rpmlb.downloader.base_rpkg import BaseRpkgDownloader
+
+
+@pytest.fixture
+def downloader():
+    return BaseRpkgDownloader()
+
+
+@pytest.fixture
+def mock_downloader(downloader):
+    downloader.command = lambda *args, **kwargs: 'testpkg'
+    return downloader
+
+
+def test_init(downloader):
+    assert downloader
+
+
+def test_command_raises_not_implemented_error(downloader):
+    with pytest.raises(NotImplementedError):
+        downloader.command()
+
+
+def test_download_passes_on_valid_arguments(mock_downloader):
+    package_dict = {'name': 'a'}
+    branch = 'private-foo'
+    with mock.patch('rpmlb.utils.run_cmd',
+                    mock.Mock(return_value=True)) as mock_run_cmd:
+        mock_downloader.download(package_dict, branch=branch)
+        cmd = r'''
+testpkg co a && \
+cd a && \
+git checkout private-foo
+        '''.strip()
+        mock_run_cmd.assert_called_once_with(cmd)
+    assert True
+
+
+def test_download_raises_error_on_without_package_dict(downloader):
+    package_dict = None
+    branch = 'private-foo'
+    with mock.patch('rpmlb.utils.run_cmd', mock.Mock(return_value=True)):
+        with pytest.raises(ValueError):
+            downloader.download(package_dict, branch=branch)
+
+
+def test_download_raises_error_on_without_branch(downloader):
+    package_dict = {'name': 'a'}
+    with pytest.raises(ValueError):
+        downloader.download(package_dict)

--- a/tests/downloader/test_base_rpkg.py
+++ b/tests/downloader/test_base_rpkg.py
@@ -11,8 +11,10 @@ def downloader():
 
 
 @pytest.fixture
-def mock_downloader(downloader):
-    downloader.command = lambda *args, **kwargs: 'testpkg'
+def mock_downloader(downloader, monkeypatch):
+    monkeypatch.setattr(type(downloader), 'command',
+                        mock.PropertyMock(return_value='testpkg'))
+
     return downloader
 
 
@@ -22,7 +24,7 @@ def test_init(downloader):
 
 def test_command_raises_not_implemented_error(downloader):
     with pytest.raises(NotImplementedError):
-        downloader.command()
+        downloader.command
 
 
 def test_download_passes_on_valid_arguments(mock_downloader):

--- a/tests/downloader/test_fedpkg.py
+++ b/tests/downloader/test_fedpkg.py
@@ -1,0 +1,7 @@
+from rpmlb.downloader.fedpkg import FedpkgDownloader
+
+
+def test_command_returns_the_value():
+    downloader = FedpkgDownloader()
+    command = downloader.command()
+    assert command == 'fedpkg'

--- a/tests/downloader/test_fedpkg.py
+++ b/tests/downloader/test_fedpkg.py
@@ -3,5 +3,4 @@ from rpmlb.downloader.fedpkg import FedpkgDownloader
 
 def test_command_returns_the_value():
     downloader = FedpkgDownloader()
-    command = downloader.command()
-    assert command == 'fedpkg'
+    assert downloader.command == 'fedpkg'

--- a/tests/downloader/test_rhpkg.py
+++ b/tests/downloader/test_rhpkg.py
@@ -3,5 +3,4 @@ from rpmlb.downloader.rhpkg import RhpkgDownloader
 
 def test_command_returns_the_value():
     downloader = RhpkgDownloader()
-    command = downloader.command()
-    assert command == 'rhpkg'
+    assert downloader.command == 'rhpkg'

--- a/tests/downloader/test_rhpkg.py
+++ b/tests/downloader/test_rhpkg.py
@@ -1,35 +1,7 @@
-from unittest import mock
-
 from rpmlb.downloader.rhpkg import RhpkgDownloader
 
 
-def test_init():
+def test_command_returns_the_value():
     downloader = RhpkgDownloader()
-    assert downloader
-
-
-def test_download():
-    downloader = RhpkgDownloader()
-    downloader.do_rhpkg_and_checkout = mock.MagicMock(return_value=True)
-    package_dict = {'name': 'a'}
-    branch = 'private-foo'
-    downloader.download(package_dict, branch=branch)
-    assert True
-
-
-""" Comment out for the kerberos auth.
-def test_do_rhpkg_and_checkout():
-    downloader = RhpkgDownloader()
-    package_dict = {'name': 'rubygem-arel'}
-    branch = 'rhscl-2.4-rh-ror50-rhel-7'
-    with helper.pushd_tmp_dir():
-        # TODO: Add check for kerberos auth.
-        downloader.do_rhpkg_and_checkout(package_dict, branch)
-        spec_file = os.path.join('1', 'rubygem-arel', 'rubygem-arel.spec')
-        assert os.path.isfile(spec_file)
-        # Show current branch
-        # git rev-parse --abbrev-ref HEAD
-        # TODO Add assert for output of below command.
-        subprocess.check_call(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
-        assert True
-"""
+    command = downloader.command()
+    assert command == 'rhpkg'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from rpmlb.cli import run
+from rpmlb import cli
 
 
 @pytest.fixture
@@ -54,7 +54,8 @@ def recipe_arguments(recipe_path):
 
 
 @pytest.mark.parametrize('option', ('recipe_file', 'collection_id', 'build',
-                                    'download', 'branch', 'source_directory'))
+                                    'download', 'branch', 'source_directory',
+                                    'pkg_cmd'))
 def test_parse_argv_no_options(tmpdir, option):
     """Tests proper default values of the CLI"""
 
@@ -73,12 +74,13 @@ def test_parse_argv_no_options(tmpdir, option):
         'download': 'none',
         'branch': None,
         'source_directory': current_dir,
+        'pkg_cmd': 'fedpkg',
     }
 
     # Parse the arguments
     with tmpdir.as_cwd():
         argv = list(map(str, [recipe_file, collection_id]))
-        args = run.make_context('rpmlb', argv).params
+        args = cli.run.make_context('rpmlb', argv).params
 
     assert args[option] == expected[option]
 
@@ -90,7 +92,7 @@ def test_log_verbosity(root_logger, runner, verbose, recipe_arguments):
     verbose_args = ['--verbose'] if verbose else []
     level = logging.DEBUG if verbose else logging.INFO
 
-    runner.invoke(run, verbose_args + recipe_arguments)
+    runner.invoke(cli.run, verbose_args + recipe_arguments)
     assert root_logger.getEffectiveLevel() == level
 
 
@@ -116,7 +118,7 @@ def path_options(path_kind):
 def test_path_nonexistent(runner, path_kind, recipe_arguments):
     path, options = path_options(path_kind)
 
-    result = runner.invoke(run, options + recipe_arguments,
+    result = runner.invoke(cli.run, options + recipe_arguments,
                            standalone_mode=False)
     assert result.exception is not None
     assert isinstance(result.exception, click.BadParameter)
@@ -130,8 +132,8 @@ def test_path_expected_and_absolute(path_kind, recipe_arguments):
     else:
         path.touch(mode=0o600)
 
-    with run.make_context('test-{}-ok'.format(path_kind),
-                          options + recipe_arguments) as ctx:
+    with cli.run.make_context('test-{}-ok'.format(path_kind),
+                              options + recipe_arguments) as ctx:
         result = Path(ctx.params[path_kind.replace('-', '_')])
     assert result == path
     assert result.is_absolute()
@@ -148,7 +150,23 @@ def test_path_bad_permissions(runner, path_kind, recipe_arguments):
         # unreadable file
         path.touch(mode=0o200)
 
-    result = runner.invoke(run, options + recipe_arguments,
+    result = runner.invoke(cli.run, options + recipe_arguments,
+                           standalone_mode=False)
+    assert result.exception is not None
+    assert isinstance(result.exception, click.BadParameter)
+
+
+@pytest.mark.parametrize('pkg_cmd', ('fedpkg', 'rhpkg'))
+def test_pkg_cmd_returns_valid_value(recipe_arguments, pkg_cmd):
+    options = ['--pkg-cmd', pkg_cmd]
+    with cli.run.make_context('test_pkg_cmd_{}_returns_value'.format(pkg_cmd),
+                              options + recipe_arguments) as ctx:
+        assert ctx.params['pkg_cmd'] == pkg_cmd
+
+
+def test_pkg_cmd_raises_error_on_invalid_options(runner, recipe_arguments):
+    options = ['--pkg-cmd', 'foo']
+    result = runner.invoke(cli.run, options + recipe_arguments,
                            standalone_mode=False)
     assert result.exception is not None
     assert isinstance(result.exception, click.BadParameter)
@@ -175,8 +193,8 @@ def test_resume_conversion(recipe_arguments):
     """Resume is converted into integer value."""
 
     options = ['--resume', '42']
-    with run.make_context('test-resume-conversion',
-                          options + recipe_arguments) as ctx:
+    with cli.run.make_context('test-resume-conversion',
+                              options + recipe_arguments) as ctx:
         assert isinstance(ctx.params['resume'], int)
 
 
@@ -184,7 +202,7 @@ def test_invalid_resume(runner, recipe_arguments):
 
     options = ['--resume', 'start']
 
-    result = runner.invoke(run, options + recipe_arguments,
+    result = runner.invoke(cli.run, options + recipe_arguments,
                            standalone_mode=False)
     assert result.exception is not None
     assert isinstance(result.exception, click.BadParameter)
@@ -199,8 +217,8 @@ def test_simple_options(recipe_arguments, option, value):
     """Specific option values are passed unprocessed."""
 
     options = ['--' + option, value]
-    with run.make_context('test-{}-passing'.format(option),
-                          options + recipe_arguments) as ctx:
+    with cli.run.make_context('test-{}-passing'.format(option),
+                              options + recipe_arguments) as ctx:
 
         assert ctx.params[option.replace('-', '_')] == value
 
@@ -211,7 +229,7 @@ def test_help_option_variants(runner, help_switch, recipe_arguments):
 
     # NOTE: recipe_arguments are necessary, both run.make_context and
     # runner.invoke break without them for some reason
-    result = runner.invoke(run, [help_switch] + recipe_arguments)
+    result = runner.invoke(cli.run, [help_switch] + recipe_arguments)
 
     assert result.exit_code == 0, result.output
 
@@ -219,9 +237,25 @@ def test_help_option_variants(runner, help_switch, recipe_arguments):
 @pytest.mark.parametrize('version_switch', ['--version'])
 def test_version_option(runner, version_switch):
     """Test that --version option displays the version"""
-    result = runner.invoke(run, [version_switch])
+    result = runner.invoke(cli.run, [version_switch])
     out = result.output.strip()
 
     assert result.exit_code == 0
     assert len(out.split('\n')) == 1
     assert 'version' in out
+
+
+@pytest.mark.parametrize('download_type', ('fedpkg', 'rhpkg'))
+def test_adjust_option_dict_sets_download_type(recipe_arguments,
+                                               download_type):
+    option_dict = {
+        'download': download_type,
+        'pkg_cmd': 'testpkg',
+    }
+    cli._adjust_option_dict(option_dict)
+    assert option_dict['pkg_cmd'] == download_type
+
+
+def test_adjust_option_dict_returns_optoin_dict_is_none():
+    cli._adjust_option_dict(None)
+    assert True


### PR DESCRIPTION
This fixes https://github.com/sclorg/rpm-list-builder/issues/66 and https://github.com/sclorg/rpm-list-builder/issues/83 .

* Added --pkg-cmd PKG_CMD command option
  PKG_CMD works in build type: mock, copr.
* Added download type: fedpkg

Specification is here https://github.com/sclorg/rpm-list-builder/issues/83#issue-245364831 .

