### PR TITLE
Fix for pylint unused-argument, unused-variable warnings.

### DIFF
--- a/rpmlb/builder/base.py
+++ b/rpmlb/builder/base.py
@@ -28,7 +28,7 @@ MACRO_REGEX = re.compile(
 class BaseBuilder:
     """A base class for the package builder."""
 
-    def __init__(self, work: Work, **options):
+    def __init__(self, _: Work, **options):
         """Initialize the builder to a valid state.
 
         Keyword arguments:
@@ -255,7 +255,7 @@ class BaseBuilder:
     def prepare_extra_steps(
         self,
         source: Iterator[str],
-        package_metadata: Mapping[str, Any]
+        _: Mapping[str, Any]
     ):
         """Builder-specific package preparation.
 

--- a/rpmlb/builder/custom.py
+++ b/rpmlb/builder/custom.py
@@ -26,8 +26,8 @@ class CustomBuilder(BaseBuilder):
         #: Custom commands runner to use
         self.custom_runner = Custom(custom_file)
 
-    def before(self, work, **kwargs):
+    def before(self, work, **_):
         self.custom_runner.run_cmds('before_build')
 
-    def build(self, package_dict, **kwargs):
+    def build(self, package_dict, **_):
         self.custom_runner.run_cmds('build', **package_dict)

--- a/rpmlb/builder/koji.py
+++ b/rpmlb/builder/koji.py
@@ -26,7 +26,7 @@ class KojiBuilder(BaseBuilder):
         koji_target_format: str = None,
         koji_owner: str = None,
         koji_profile: Optional[str] = None,
-        **extra_options
+        **_
     ):
         """Initialize the builder.
 

--- a/rpmlb/builder/mock.py
+++ b/rpmlb/builder/mock.py
@@ -26,7 +26,7 @@ class MockBuilder(BaseBuilder):
         #: Name of the Mock configuration profile to use
         self.mock_config = mock_config
 
-    def before(self, work, **kwargs):
+    def before(self, work, **_):
         utils.run_cmd('mock -r {} --scrub=all'.format(self.mock_config))
 
     def build(self, package_dict, **kwargs):

--- a/rpmlb/downloader/base.py
+++ b/rpmlb/downloader/base.py
@@ -45,7 +45,7 @@ class BaseDownloader:
 
         self.before(work, **kwargs)
 
-        for package_dict, num_name in work.each_num_dir():
+        for package_dict, _ in work.each_num_dir():
             if self._is_download_skipped(package_dict, **kwargs):
                 name = package_dict['name']
                 LOG.debug('Skip download package: %s', name)


### PR DESCRIPTION
I ran `pylint` to know Python better practices in my repository (https://github.com/junaruga/rpm-list-builder/tree/feature/add-pylint) as a trial.

And I fixed below unused-argument and unused-variable warnings.
How do you think?

```
rpmlb/builder/custom.py:29: [W0613(unused-argument), CustomBuilder.before] Unused argument 'kwargs'
rpmlb/builder/mock.py:29: [W0613(unused-argument), MockBuilder.before] Unused argument 'kwargs'
rpmlb/builder/base.py:31: [W0613(unused-argument), BaseBuilder.__init__] Unused argument 'work'
rpmlb/builder/base.py:258: [W0613(unused-argument), BaseBuilder.prepare_extra_steps] Unused argument 'package_metadata'
rpmlb/builder/koji.py:21: [W0613(unused-argument), KojiBuilder.__init__] Unused argument 'extra_options'
rpmlb/downloader/base.py:48: [W0612(unused-variable), BaseDownloader.run] Unused variable 'num_name'
```
