### PR TITLE
Fix naming of packages added to target koji tag

### DIFF
--- a/tests/builder/test_koji.py
+++ b/tests/builder/test_koji.py
@@ -6,6 +6,7 @@ from itertools import zip_longest
 from logging import DEBUG
 from pathlib import Path
 from textwrap import dedent
+from unittest.mock import Mock
 
 import pytest
 
@@ -61,13 +62,6 @@ def work(valid_recipe_path, collection_id):
     return Work(valid_recipe)
 
 
-@pytest.fixture
-def builder(work):
-    """Provide minimal KojiBuilder instance."""
-
-    return KojiBuilder(work, koji_epel=7, koji_owner='test-owner')
-
-
 @pytest.fixture(params=[
     KojiBuilder.DEFAULT_TARGET_FORMAT,
     'test-target',
@@ -84,6 +78,13 @@ def epel(request):
     """EPEL version number"""
 
     return request.param
+
+
+@pytest.fixture
+def builder(work, epel):
+    """Provide minimal KojiBuilder instance."""
+
+    return KojiBuilder(work, koji_epel=epel, koji_owner='test-owner')
 
 
 @pytest.fixture(params=[None, 'koji', 'cbs'])
@@ -114,6 +115,21 @@ def cli_parameters(target_format, epel, profile, scratch_build):
         # Extra parameter to assure the builder can take them
         'copr_repo': 'test/example',
     }
+
+
+@pytest.fixture
+def mock_runner(monkeypatch):
+    """Mock shell command runner with command recording."""
+
+    runner = Mock(return_value=None)
+    monkeypatch.setattr('rpmlb.builder.koji.run_cmd', runner)
+    monkeypatch.setattr('rpmlb.builder.koji.run_cmd_with_capture', runner)
+
+    # Also patch _make_srpm which fails if runner has no side effect
+    mock_srpm = Mock(return_value=Path('test.src.rpm'))
+    monkeypatch.setattr(KojiBuilder, '_make_srpm', mock_srpm)
+
+    return runner
 
 
 def test_init_sets_attributes(work, cli_parameters):
@@ -177,13 +193,13 @@ def test_target_respects_format(
     assert builder.target == expected_target
 
 
-def test_make_srpm_creates_srpm(spec_path, collection_id, epel):
+def test_make_srpm_creates_srpm(builder, spec_path, collection_id, epel):
     """Ensure that make_srpm works as expected"""
 
     configure_logging(DEBUG)
 
     arguments = {
-        'base_name': spec_path.stem,
+        'name': spec_path.stem,
         'collection': collection_id,
         'epel': epel,
     }
@@ -192,24 +208,24 @@ def test_make_srpm_creates_srpm(spec_path, collection_id, epel):
         # Metapackage
         '{collection}-1-1.el{epel}.src.rpm'.format_map(arguments),
         # Regular package
-        '{collection}-{base_name}-1.0-1.el{epel}.src.rpm'.format_map(
+        '{collection}-{name}-1.0-1.el{epel}.src.rpm'.format_map(
             arguments,
         ),
     }
 
-    srpm_path = KojiBuilder._make_srpm(**arguments)
+    srpm_path = builder._make_srpm(arguments['name'])
 
     assert srpm_path.exists(), srpm_path
     assert srpm_path.name in possible_names
 
 
-def test_missing_spec_is_reported(tmpdir):
+def test_missing_spec_is_reported(tmpdir, builder):
     """make_srpm does not attempt to build nonexistent SPEC file"""
 
     configure_logging(DEBUG)
 
     with tmpdir.as_cwd(), pytest.raises(FileNotFoundError):
-        KojiBuilder._make_srpm(base_name='test', collection='test', epel=7)
+        builder._make_srpm(name='test')
 
 
 def test_prepare_adjusts_bootstrap_release(builder, spec_contents):
@@ -231,22 +247,9 @@ def test_prepare_adjusts_bootstrap_release(builder, spec_contents):
     (False, ['koji add-pkg', 'koji build', 'koji wait-repo']),
 ])
 def test_build_emit_correct_commands(
-    monkeypatch, builder, scratch, expected_commands
+    monkeypatch, mock_runner, builder, scratch, expected_commands
 ):
     """Builder emits expected commands on build."""
-
-    # Gather all emitted commands
-    commands = []
-    monkeypatch.setattr(
-        'rpmlb.builder.koji.run_cmd',
-        lambda cmd, **__: commands.append(cmd),
-    )
-
-    # Skip make_srpm, as it requires the run_cmd to actually do something
-    monkeypatch.setattr(
-        KojiBuilder, '_make_srpm',
-        lambda *_, **__: Path('test.src.rpm'),
-    )
 
     # Provide hardcoded destination tag
     monkeypatch.setattr(KojiBuilder, '_destination_tag', 'test_tag_name')
@@ -254,15 +257,18 @@ def test_build_emit_correct_commands(
     builder.scratch_build = scratch
     builder.build({'name': 'test'})
 
+    commands = mock_runner.call_args_list
     command_pairs = zip_longest(commands, expected_commands)
     assert all(cmd.startswith(exp) for cmd, exp in command_pairs), commands
 
 
-def test_destination_tag_parsed_correctly(monkeypatch, builder):
+def test_destination_tag_parsed_correctly(mock_runner, builder):
     """Assert that the destination tag is correctly extracted from output."""
 
     # Simulate output of `koji list-targets`
-    raw_output = namedtuple('MockCommandOutput', ['stdout', 'stderr'])(
+    mock_runner.return_value = namedtuple(
+        'MockCommandOutput', ['stdout', 'stderr']
+    )(
         stderr=b'',
         stdout=dedent('''\
         Name                Buildroot           Destination
@@ -271,23 +277,13 @@ def test_destination_tag_parsed_correctly(monkeypatch, builder):
         ''').encode('utf-8')
     )
 
-    monkeypatch.setattr(
-        'rpmlb.builder.koji.run_cmd_with_capture',
-        lambda *_, **__: raw_output,
-    )
-
     builder.target_format = 'test-target'
     assert builder._destination_tag == 'test-tag-candidate'
 
 
-def test_add_package_respects_owner(monkeypatch, builder):
+def test_add_package_respects_owner(monkeypatch, mock_runner, builder):
     """Assert that the owner is used by the _add_package method."""
 
-    commands = []
-    monkeypatch.setattr(
-        'rpmlb.builder.koji.run_cmd',
-        lambda cmd, **__: commands.append(cmd),
-    )
     monkeypatch.setattr(
         KojiBuilder, '_destination_tag', 'test-destination'
     )
@@ -295,9 +291,9 @@ def test_add_package_respects_owner(monkeypatch, builder):
     builder.owner = 'expected-owner'
     builder._add_package(name='test')
 
-    assert len(commands) == 1
+    assert mock_runner.call_count == 1
 
-    cmd, = commands
+    cmd = mock_runner.call_args[0][0]
     assert '--owner' in cmd
     assert builder.owner in cmd
 
@@ -307,7 +303,6 @@ def test_add_package_respects_owner(monkeypatch, builder):
     ('ruby', 'rh-ror50-ruby'),
 ])
 def test_full_name_is_resolved_correctly(builder, package_name, expected):
-    """Assert that build adds the package with correct name."""
+    """Ensure the correct form of full package name."""
 
-    full_name = builder._full_package_name(package_name, builder.collection)
-    assert full_name == expected
+    assert builder._full_package_name(package_name) == expected


### PR DESCRIPTION
`KojiBuilder` was incorrectly handling naming of metapackages when adding them to target tag, essentialy duplicated the collection name (i.e. adding `rh-ror50-rh-ror50` in place of just `rh-ror50`).

This fix adds a check for the metapackage name, avoiding the duplication.