### PR TITLE
Retrieve sources from lookaside cache with {fed,rh}pkg

### DIFF
--- a/rpmlb/downloader/base_rpkg.py
+++ b/rpmlb/downloader/base_rpkg.py
@@ -22,8 +22,13 @@ class BaseRpkgDownloader(BaseDownloader):
 
         package = package_dict['name']
         cmd = r'''
-{} co {} && \
-cd {} && \
-git checkout {}
-        '''.strip().format(self.command, package, package, branch)
+{command} co {package} && \
+cd {package} && \
+git checkout {branch} && \
+{command} sources
+        '''.strip().format(
+            command=self.command,
+            package=package,
+            branch=branch,
+        )
         utils.run_cmd(cmd)

--- a/tests/downloader/test_base_rpkg.py
+++ b/tests/downloader/test_base_rpkg.py
@@ -36,7 +36,8 @@ def test_download_passes_on_valid_arguments(mock_downloader):
         cmd = r'''
 testpkg co a && \
 cd a && \
-git checkout private-foo
+git checkout private-foo && \
+testpkg sources
         '''.strip()
         mock_run_cmd.assert_called_once_with(cmd)
     assert True


### PR DESCRIPTION
When using the `{fed,rh}pkg` downloader, also retrieve the sources from the lookaside cache.

---

The koji builder cannot build an SRPM in the working directory if it does not have all the package sources and patches available, since it does not rely on any `*pkg` command, but uses `rpm`/`rpmbuild` directly. The other relevant builders (except the custom one, which leaves that up to the user) all use `*pkg srpm` for building the SRPM, which calls `*pkg sources` if necessary.

The koji builder could of course be adapted to using the `*pkg` command internally, but I believe this to be an unnecessary coupling/dependency. With this patch, both ways will be working.

Thoughts?